### PR TITLE
Fix crashing during resizing.

### DIFF
--- a/LvglWindowsDesktopApplication/LvglWindowsDesktopApplication.cpp
+++ b/LvglWindowsDesktopApplication/LvglWindowsDesktopApplication.cpp
@@ -850,6 +850,7 @@ void LvglTaskSchedulerLoop()
         if (g_WindowResizingSignal)
         {
             lv_disp_t* CurrentDisplay = ::lv_display_get_default();
+            g_WindowResizingSignal = false;
             if (CurrentDisplay)
             {
                 ::LvglCreateDisplayDriver(
@@ -860,11 +861,10 @@ void LvglTaskSchedulerLoop()
                     CurrentDisplay,
                     static_cast<std::int32_t>(g_WindowWidth),
                     static_cast<std::int32_t>(g_WindowHeight));
-
-                ::lv_refr_now(CurrentDisplay);
+                continue;
+                //::lv_refr_now(CurrentDisplay);
             }
 
-            g_WindowResizingSignal = false;
         }
 
         ::lv_timer_handler();


### PR DESCRIPTION
I run this project on my computer today, hoping to integrate it into my project later, but I found this issue.   
When I resize the window quickly for about 5 seconds, it crashes like this.   
![2023-12-18 230228](https://github.com/lvgl/lv_port_pc_visual_studio/assets/148050370/38ae30be-3580-4eca-b479-3eec3380d2eb)
And it takes me about three hours trying to figure out what's wrong. Finally, I changed these lines of codes and unexpectedly soved this problem. So I opened this PR.  

P.S. I also tried to comment `::lv_refr_now(CurrentDisplay);`, but it doesn't work. The result is as follows.  
![2023-12-18 230917](https://github.com/lvgl/lv_port_pc_visual_studio/assets/148050370/e006bc3e-0a02-484a-8adf-4acd64f02b91)

Environment Information:  
Windows 10 LTSC 10.0.19044  
Intel(R) Core(TM) i7-4720HQ CPU @ 2.60GHz  
Microsoft Visual Studio Community 2022  
Microsoft Visual C++ 2022  
lvgl/lv_port_pc_visual_studio@master  
lvgl/lvgl@0f9ee575   
freetype/freetype@8f255c89  
dlg@72dfcc85  


